### PR TITLE
v1.3.0: macOS support, `.wav`/`.ogg`/`.oga`/`.flac` support, behavioral corrections, etc

### DIFF
--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -15,8 +15,8 @@ jobs:
           - name: Windows
             os: windows-latest
 
-          # - name: macOS
-          #   os: macos-latest
+          - name: macOS
+            os: macos-latest
 
           - name: Android32
             os: ubuntu-latest

--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -35,9 +35,9 @@ jobs:
       - name: Build the mod
         uses: geode-sdk/build-geode-mod@main
         with:
-          cli: "v3.0.0"
-          bindings: geode-sdk/bindings
-          bindings-ref: main
+          # cli: "v3.0.0" # not sure why this is here --raydeeux
+          bindings: RayDeeUx/bindings # comment this out to use geode-sdk/bindings
+          bindings-ref: i-know-this-is-behind-but-i-need-it-for-menulooprandomizer # comment this out to use default branch
           combine: true
           target: ${{ matrix.config.target }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ build-*/
 
 # Visual Studio
 .vs/
+/cmake-*/

--- a/about.md
+++ b/about.md
@@ -2,27 +2,30 @@
 
 Are you bored of hearing the same menu song <cr>over & over</cr>? Well... **No more of that!**
 
-This mod allows you to randomize the menu song every time you open the game, picking from a random downloaded song from Newgrounds, RobTop's music library, or your own songs. `.mp3`, `.ogg`, `.oga`, and `.wav` files are supported.
+This mod allows you to randomize the menu song every time you open the game, picking from a random downloaded song from Newgrounds, RobTop's Music Library, or your own songs. `.mp3`, `.ogg`, `.oga`, and `.wav` files are supported.
 
-## For macOS users
+## For macOS Intel users
 
-Due to incomplete bindings, <cr>this mod will not play songs downloaded from Newgrounds or RobTop's music library on macOS</cr>. <cy>Only custom songs are supported on macOS.</cy> Read below to learn more.
+Due to incomplete bindings, <cr>this mod will not play songs downloaded from Newgrounds on macOS Intel devices</cr>. <cy>Only custom songs or songs from RobTop's Music Library are supported on macOS Intel.</cy> Read below to learn more.
 
 # How to add custom songs
 
-If you want to add your own songs to the mod you should go to the settings tab, then click the folder button. Just like with grabbing songs you've downloaded from Newgrounds or RobTop's music library, `.mp3`, `.ogg`, `.oga`, and `.wav` files are supported.
+If you want to add your own songs to the mod you should go to the settings tab, then click the <c>pink</c> folder button. Just like with grabbing songs you've downloaded from Newgrounds or RobTop's music library, `.mp3` and `.ogg` files are supported.
 
-![Screenshot on how to use it](elnexreal.menuloop_randomizer/screenshot.png)
+`.oga`, `.flac` and `.wav` files are also supported for the few audiophiles who want the highest of audio quality out there.
+
+![Screenshot on how to use it. Install the mod to view this screenshot!](elnexreal.menuloop_randomizer/screenshot.png)
 
 ## Android
 
-<co>*If you click the folder and you get sent to the geode folder itself, you should go to game/geode/config/elnexreal.menuloop_randomizer and put the songs there*</co>
+<co>*If you click the folder and you get sent to the geode folder itself, you should go to `game/geode/config/elnexreal.menuloop_randomizer` and put the songs there*</co>
 
 # Thanks to!
 
-- [hiimjustin000](https://github.com/hiimjustin000) <cj>for helping me with the bindings problem (i was using an outdated version of geode LMAO)</cj>
+- [hiimjustin000](https://github.com/hiimjustin000) <cj>for helping me with the bindings problem (i was using an outdated version of geode LMAO).</cj>
 - [km7dev](https://github.com/Kingminer7) <cj>for helping me with the constant crashes and testing.</cj>
-- <cj>Shaday for giving me the idea<cj>
+- <cj>Shaday for giving me the idea.<cj>
 - [dank_meme](https://github.com/dankmeme01) <cj>for helping me with singletons.</cj>
-- [raydeeux](https://github.com/RayDeeUx) <cy>for porting part of the mod to macOS, and adding `.ogg`/`.oga`/`.wav` file support</cj>
+- [ninxout](https://github.com/ninXout) <cy>for porting part of the mod to macOS, and adding Music Library support.</c>
+- [raydeeux](https://github.com/RayDeeUx) <cy>for porting part of the mod to macOS, and adding `.ogg`/`.oga`/`.wav`/`.flac` file support for custom songs.</cj>
 - [Feather Icons](https://feathericons.com) <cj>for providing the shuffle icon.</cj>

--- a/about.md
+++ b/about.md
@@ -2,15 +2,15 @@
 
 Are you bored of hearing the same menu song <cr>over & over</cr>? Well... **No more of that!**
 
-This mod allows you to randomize the menu song every time you open the game, picking from a random downloaded song from Newgrounds or your own songs.
+This mod allows you to randomize the menu song every time you open the game, picking from a random downloaded song from Newgrounds, RobTop's music library, or your own songs. `.mp3`, `.ogg`, `.oga`, and `.wav` files are supported.
 
 ## For macOS users
 
-Due to incomplete bindings, <cr>this mod will not play songs downloaded from Newgrounds on macOS</cr>. <cy>Only custom songs are supported on macOS.</cy> Read below to learn more.
+Due to incomplete bindings, <cr>this mod will not play songs downloaded from Newgrounds or RobTop's music library on macOS</cr>. <cy>Only custom songs are supported on macOS.</cy> Read below to learn more.
 
 # How to add custom songs
 
-If you want to add your own songs to the mod you should go to the settings tab, then click the folder button.
+If you want to add your own songs to the mod you should go to the settings tab, then click the folder button. Just like with grabbing songs you've downloaded from Newgrounds or RobTop's music library, `.mp3`, `.ogg`, `.oga`, and `.wav` files are supported.
 
 ![Screenshot on how to use it](elnexreal.menuloop_randomizer/screenshot.png)
 
@@ -24,5 +24,5 @@ If you want to add your own songs to the mod you should go to the settings tab, 
 - [km7dev](https://github.com/Kingminer7) <cj>for helping me with the constant crashes and testing.</cj>
 - <cj>Shaday for giving me the idea<cj>
 - [dank_meme](https://github.com/dankmeme01) <cj>for helping me with singletons.</cj>
-- [raydeeux](https://github.com/RayDeeUx) <cy>for porting part of the mod to macOS.</cj>
+- [raydeeux](https://github.com/RayDeeUx) <cy>for porting part of the mod to macOS, and adding `.ogg`/`.oga`/`.wav` file support</cj>
 - [Feather Icons](https://feathericons.com) <cj>for providing the shuffle icon.</cj>

--- a/about.md
+++ b/about.md
@@ -6,7 +6,7 @@ This mod allows you to randomize the menu song every time you open the game, pic
 
 # How to add custom songs
 
-If you want to add your own songs to the mod you should go to the settings tab, then click the <c>pink</c> folder button. Just like with grabbing songs you've downloaded from Newgrounds or RobTop's music library, `.mp3` and `.ogg` files are supported.
+If you want to add your own songs to the mod you should go to the settings tab, then click the <cd>pink</c> folder button. Just like with grabbing songs you've downloaded from Newgrounds or RobTop's music library, `.mp3` and `.ogg` files are supported.
 
 ![Screenshot on how to use it. Install the mod to view this screenshot!](elnexreal.menuloop_randomizer/screenshot.png)
 

--- a/about.md
+++ b/about.md
@@ -6,7 +6,7 @@ This mod allows you to randomize the menu song every time you open the game, pic
 
 # How to add custom songs
 
-If you want to add your own songs to the mod you should go to the settings tab, then click the <cd>pink</c> folder button. Just like with grabbing songs you've downloaded from Newgrounds or RobTop's music library, `.mp3` and `.ogg` files are supported.
+If you want to add your own songs to the mod you should go to the settings tab, then click the <cd>pink</c> folder button. Just like with grabbing songs you've downloaded from Newgrounds or RobTop's Music Library, `.mp3` and `.ogg` files are supported.
 
 ![Screenshot on how to use it. Install the mod to view this screenshot!](elnexreal.menuloop_randomizer/screenshot.png)
 

--- a/about.md
+++ b/about.md
@@ -2,7 +2,7 @@
 
 Are you bored of hearing the same menu song <cr>over & over</cr>? Well... **No more of that!**
 
-This mod allows you to randomize the menu song every time you open the game, picking from a random downloaded song from Newgrounds, RobTop's Music Library, or your own songs. `.mp3`, `.ogg`, `.oga`, and `.wav` files are supported.
+This mod allows you to randomize the menu song every time you open the game, picking from a random downloaded song from Newgrounds, RobTop's Music Library, or your own songs. `.mp3`, `.ogg`/`.oga`, `.wav`, and `.flac` files are supported.
 
 # How to add custom songs
 

--- a/about.md
+++ b/about.md
@@ -4,6 +4,10 @@ Are you bored of hearing the same menu song <cr>over & over</cr>? Well... **No m
 
 This mod allows you to randomize the menu song every time you open the game, picking from a random downloaded song from Newgrounds or your own songs.
 
+## For macOS users
+
+Due to incomplete bindings, <cr>this mod will not play songs downloaded from Newgrounds on macOS</cr>. <cy>Only custom songs are supported on macOS.</cy> Read below to learn more.
+
 # How to add custom songs
 
 If you want to add your own songs to the mod you should go to the settings tab, then click the folder button.
@@ -20,4 +24,5 @@ If you want to add your own songs to the mod you should go to the settings tab, 
 - [km7dev](https://github.com/Kingminer7) <cj>for helping me with the constant crashes and testing.</cj>
 - <cj>Shaday for giving me the idea<cj>
 - [dank_meme](https://github.com/dankmeme01) <cj>for helping me with singletons.</cj>
+- [raydeeux](https://github.com/RayDeeUx) <cy>for porting part of the mod to macOS.</cj>
 - [Feather Icons](https://feathericons.com) <cj>for providing the shuffle icon.</cj>

--- a/about.md
+++ b/about.md
@@ -4,17 +4,13 @@ Are you bored of hearing the same menu song <cr>over & over</cr>? Well... **No m
 
 This mod allows you to randomize the menu song every time you open the game, picking from a random downloaded song from Newgrounds, RobTop's Music Library, or your own songs. `.mp3`, `.ogg`, `.oga`, and `.wav` files are supported.
 
-## For macOS Intel users
-
-Due to incomplete bindings, <cr>this mod will not play songs downloaded from Newgrounds on macOS Intel devices</cr>. <cy>Only custom songs or songs from RobTop's Music Library are supported on macOS Intel.</cy> Read below to learn more.
-
 # How to add custom songs
 
 If you want to add your own songs to the mod you should go to the settings tab, then click the <c>pink</c> folder button. Just like with grabbing songs you've downloaded from Newgrounds or RobTop's music library, `.mp3` and `.ogg` files are supported.
 
-`.oga`, `.flac` and `.wav` files are also supported for the few audiophiles who want the highest of audio quality out there.
-
 ![Screenshot on how to use it. Install the mod to view this screenshot!](elnexreal.menuloop_randomizer/screenshot.png)
+
+`.oga`, `.flac` and `.wav` files are also supported for the few audiophiles who want the highest of audio quality out there.
 
 ## Android
 
@@ -26,6 +22,6 @@ If you want to add your own songs to the mod you should go to the settings tab, 
 - [km7dev](https://github.com/Kingminer7) <cj>for helping me with the constant crashes and testing.</cj>
 - <cj>Shaday for giving me the idea.<cj>
 - [dank_meme](https://github.com/dankmeme01) <cj>for helping me with singletons.</cj>
-- [ninxout](https://github.com/ninXout) <cy>for porting part of the mod to macOS, and adding Music Library support.</c>
-- [raydeeux](https://github.com/RayDeeUx) <cy>for porting part of the mod to macOS, and adding `.ogg`/`.oga`/`.wav`/`.flac` file support for custom songs.</cj>
+- [ninxout](https://github.com/ninXout) <cj>for porting part of the mod to macOS, and adding Music Library support.</c>
+- [raydeeux](https://github.com/RayDeeUx) <cj>for porting part of the mod to macOS, and adding `.ogg`/`.oga`/`.wav`/`.flac` file support for custom songs.</cj>
 - [Feather Icons](https://feathericons.com) <cj>for providing the shuffle icon.</cj>

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,11 @@
 # v1.3.0
 
-- Added partial macOS support [custom songs only]
-- Added support for `.wav`, `.ogg`, and `.oga` files (thx [raydeeux](https://github.com/RayDeeUx))
-- Set Z order of the "Now Playing" notification to 200 for easier readability against MenuLayer mods such as Overcharged Main Menu 
+- Added macOS support (thx [ninxout](https://github.com/ninXout), [raydeeux](https://github.com/RayDeeUx), and [hiimjustin000](https://github.com/hiimjustin000))
+- Added support for `.wav`, `.ogg`/`.oga`, and `.flac` files for custom songs
+- Set Z order of the "Now Playing" notification to 200 for easier readability against most MenuLayer mods (such as Overcharged Main Menu)
+- Shuffling the song now generates a new "Now Playing" notification
+- Increase "Now Playing" notification maximum duration to 5 seconds
+- Squash a few bugs, optimize a few things, minimize likelihood of potential crashes
 
 # v1.2.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
 - Set Z order of the "Now Playing" notification to 200 for easier readability against most MenuLayer mods (such as Overcharged Main Menu)
 - Shuffling the song now generates a new "Now Playing" notification
 - Increase "Now Playing" notification maximum duration to 5 seconds
+- Add better slider control for adjusting notification duration
+- Added Node IDs to nodes added by this mod
 - Squash a few bugs, optimize a few things, minimize likelihood of potential crashes
 
 # v1.2.2

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # v1.3.0
 
 - Added partial macOS support [custom songs only] (thx [raydeeux](https://github.com/RayDeeUx))
+- Added support for `.wav` files
 
 # v1.2.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # v1.3.0
 
 - Added partial macOS support [custom songs only] (thx [raydeeux](https://github.com/RayDeeUx))
-- Added support for `.wav` files
+- Added support for `.wav`, `.ogg`, and `.oga` files
 
 # v1.2.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
 # v1.3.0
 
-- Added partial macOS support [custom songs only] (thx [raydeeux](https://github.com/RayDeeUx))
-- Added support for `.wav`, `.ogg`, and `.oga` files
+- Added partial macOS support [custom songs only]
+- Added support for `.wav`, `.ogg`, and `.oga` files (thx [raydeeux](https://github.com/RayDeeUx))
+- Set Z order of the "Now Playing" notification to 200 for easier readability against MenuLayer mods such as Overcharged Main Menu 
 
 # v1.2.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 - Added macOS support (thx [ninxout](https://github.com/ninXout), [raydeeux](https://github.com/RayDeeUx), and [hiimjustin000](https://github.com/hiimjustin000))
 - Added support for `.wav`, `.ogg`/`.oga`, and `.flac` files for custom songs
+- Included artist name for all "Now Playing" notifications
 - Set Z order of the "Now Playing" notification to 200 for easier readability against most MenuLayer mods (such as Overcharged Main Menu)
 - Shuffling the song now generates a new "Now Playing" notification
 - Increase "Now Playing" notification maximum duration to 5 seconds

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# v1.3.0
+
+- Added partial macOS support [custom songs only] (thx [raydeeux](https://github.com/RayDeeUx))
+
 # v1.2.2
 
 - Added an option to enable the shuffle button (thx [reinmar](https://github.com/Reinmmar))

--- a/mod.json
+++ b/mod.json
@@ -56,7 +56,7 @@
 		"useCustomSongs": {
 			"type": "bool",
 			"default": false,
-			"description": "Use your own songs instead of those you have downloaded from Newgrounds or RobTop's music library.\n\n<cy>Find instructions in the mod info popup.</c>",
+			"description": "Use your own songs instead of those you have downloaded from Newgrounds or RobTop's Music Library.\n\n<cy>Find instructions in the mod info popup.</c>",
 			"name": "Use Custom Songs Instead"
 		}
 	},

--- a/mod.json
+++ b/mod.json
@@ -57,8 +57,7 @@
 			"type": "bool",
 			"default": false,
 			"description": "Use your own songs instead of those you have downloaded from Newgrounds or RobTop's music library.\n\n<cy>Find instructions in the mod info popup.</c>",
-			"name": "Use custom songs path",
-			"platforms": ["win", "android"]
+			"name": "Use Custom Songs Instead"
 		}
 	},
 	"resources": {

--- a/mod.json
+++ b/mod.json
@@ -37,7 +37,7 @@
 			"type": "float",
 			"default": 0.5,
 			"min": 0.1,
-			"max": 2,
+			"max": 5,
 			"description": "Adjust the time that the notification is on screen.",
 			"name": "Notification Time"
 		},

--- a/mod.json
+++ b/mod.json
@@ -1,10 +1,11 @@
 {
-	"geode": "3.2.0",
+	"geode": "3.4.0",
 	"gd": {
 		"win": "2.206",
+		"mac": "2.206",
 		"android": "2.206"
 	},
-	"version": "v1.2.2",
+	"version": "v1.3.0",
 	"id": "elnexreal.menuloop_randomizer",
 	"name": "Menu Loop Randomizer",
 	"developer": "elnexreal",
@@ -24,39 +25,40 @@
 			"type": "bool",
 			"default": true,
 			"description": "Enables the <cj>shuffle button</c> in the main menu",
-			"name": "Enable shuffle button"
+			"name": "Shuffle Button"
 		},
 		"enableNotification": {
 			"type": "bool",
 			"default": true,
 			"description": "Shows a notification with the name of the currently playing song.",
-			"name": "Show notification"
+			"name": "Show Notification"
 		},
 		"notificationTime": {
 			"type": "float",
 			"default": 0.5,
 			"min": 0.1,
 			"max": 2,
-			"description": "Modify the time that the notification is on screen",
-			"name": "Notification time"
+			"description": "Adjust the time that the notification is on screen.",
+			"name": "Notification Time"
 		},
 		"randomizeWhenExitingLevel": {
 			"type": "bool",
 			"default": true,
-			"description": "Randomize the song when you exit a level",
-			"name": "Randomize on level exit"
+			"description": "Randomize the song when you exit a level.",
+			"name": "Randomize on Level Exit"
 		},
 		"randomizeWhenExitingEditor": {
 			"type": "bool",
 			"default": true,
-			"description": "Randomize the song when you exit the editor",
-			"name": "Randomize on editor exit"
+			"description": "Randomize the song when you exit the editor.",
+			"name": "Randomize on Editor Exit"
 		},
 		"useCustomSongs": {
 			"type": "bool",
 			"default": false,
 			"description": "Use your own songs instead of Newgrounds's (instructions are on the about.md file)",
-			"name": "Use custom songs path"
+			"name": "Use custom songs path",
+			"platforms": ["win", "android"]
 		}
 	},
 	"resources": {

--- a/mod.json
+++ b/mod.json
@@ -39,7 +39,16 @@
 			"min": 0.1,
 			"max": 5,
 			"description": "Adjust the time that the notification is on screen.",
-			"name": "Notification Time"
+			"name": "Notification Time",
+			"control": {
+				"input": true,
+				"slider": true,
+				"arrows": true,
+				"big-arrows": true,
+				"arrow-step": 0.5,
+				"big-arrow-step": 1,
+				"slider-step": 0.1
+			}
 		},
 		"randomizeWhenExitingLevel": {
 			"type": "bool",

--- a/mod.json
+++ b/mod.json
@@ -56,7 +56,7 @@
 		"useCustomSongs": {
 			"type": "bool",
 			"default": false,
-			"description": "Use your own songs instead of Newgrounds's (instructions are on the about.md file)",
+			"description": "Use your own songs instead of those you have downloaded from Newgrounds or RobTop's music library.\n\n<cy>Find instructions in the mod info popup.</c>",
 			"name": "Use custom songs path",
 			"platforms": ["win", "android"]
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,6 +137,7 @@ struct MenuLayerHook : Modify<MenuLayerHook, MenuLayer> {
 			auto posy = defaultPos.y;
 
 			card->setPosition(defaultPos);
+			card->setZOrder(200);
 			this->addChild(card);
 
 			auto sequence = CCSequence::create(
@@ -205,6 +206,10 @@ struct OptionsLayerHook : Modify<OptionsLayerHook, OptionsLayer> {
 	}
 };
 
+bool isSupportedExtension(std::string path) {
+	return path.ends_with(".mp3") || path.ends_with(".wav") || path.ends_with(".ogg") || path.ends_with(".oga");
+}
+
 void populateVector(bool customSongs) {
 	/*
 		if custom songs are enabled search for files in the config dir
@@ -220,7 +225,7 @@ void populateVector(bool customSongs) {
 
 		for (auto file : std::filesystem::directory_iterator(configPath)) {
 			auto filePathString = file.path().string();
-			if (filePathString.ends_with(".mp3") || filePathString.ends_with(".wav")) {
+			if (isSupportedExtension(filePathString)) {
 				log::debug("Adding custom song: {}", file.path().filename().string());
 				songManager.addSong(filePathString);
 			}
@@ -235,7 +240,7 @@ void populateVector(bool customSongs) {
 		for (auto song : songs) {
 			std::string songPath = downloadManager->pathForSong(song->m_songID);
 
-			if (songPath.ends_with(".mp3")) {
+			if (isSupportedExtension(songPath)) {
 				log::debug("Adding NG song: {}", songPath);
 				songManager.addSong(songPath);
 			}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,7 +134,7 @@ struct MenuLayerHook : Modify<MenuLayerHook, MenuLayer> {
 		std::string notifString = "Now playing: ";
 
 		if (Mod::get()->getSettingValue<bool>("useCustomSongs")) {
-			notifString = notifString.append(songFileName);
+			notifString = notifString.append(songFileName.string());
 		} else {
 			// in case that the current file selected is the original menuloop, don't gather any info
 			if (songManager.isOriginalMenuLoop()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -249,22 +249,34 @@ void populateVector(bool customSongs) {
 			}
 		}
 	} else {
-		#ifndef GEODE_IS_MACOS
 		auto downloadManager = MusicDownloadManager::sharedState();
 
 		// for every downloaded song push it to the m_songs vector
+		/*
+		getDownloadedSongs() function call binding for macOS found
+		from ninXout (ARM) and hiimjustin000 (Intel + verification)
+		*/
 		CCArrayExt<SongInfoObject *> songs = downloadManager->getDownloadedSongs();
 		for (auto song : songs) {
 			std::string songPath = downloadManager->pathForSong(song->m_songID);
 
-			if (isSupportedExtension(songPath)) {
-				log::debug("Adding NG song: {}", songPath);
-				songManager.addSong(songPath);
-			}
-		}
-		#else
+			if (!isSupportedExtension(songPath))
+				continue;
 
-		#endif
+			log::debug("Adding Newgrounds song: {}", songPath);
+			songManager.addSong(songPath);
+		}
+		// same thing as NG but for music library as well --ninXout
+		std::filesystem::path mlsongs = geode::dirs::getGeodeDir().parent_path() / "Resources" / "songs";
+		for (const std::filesystem::path& dirEntry : std::filesystem::recursive_directory_iterator(mlsongs)) {
+			std::string songPath = dirEntry.string();
+
+			if (!isSupportedExtension(songPath))
+				continue;
+
+			log::debug("Adding Music Library song: {}", songPath);
+			songManager.addSong(songPath);
+		}
 	}
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,9 +219,10 @@ void populateVector(bool customSongs) {
 		auto configPath = geode::Mod::get()->getConfigDir();
 
 		for (auto file : std::filesystem::directory_iterator(configPath)) {
-			if (file.path().string().ends_with(".mp3")) {
+			auto filePathString = file.path().string();
+			if (filePathString.ends_with(".mp3") || filePathString.ends_with(".wav")) {
 				log::debug("Adding custom song: {}", file.path().filename().string());
-				songManager.addSong(file.path().string());
+				songManager.addSong(filePathString);
 			}
 		}
 	}


### PR DESCRIPTION
- macOS support. (with help from @ninXout and @hiimjustin000 for bindings)
- Music Library support. (merged from @ninXout's personal changes via `.patch` file)
- `.wav`/`.ogg`/`.oga`/`.flac` support because FMOD is sometimes based. I could add `.flac` too, but from personal experience with PauseMenuLoop I haven't gotten any requests for that yet. In any case it'd be a boolean condition.
- Capitalized the names of a few settings and rephrased a few things here and there.
- Reduce likelihood of `nullptr` crash with `SongInfo*` class.

Marking this as a draft PR; @ninxout is working on a macOS ARM port and I don't want to cause merge conflicts. I would rather have the "macOS support" update cover as much ground as possible from day one.